### PR TITLE
Generate srv msgs first, then build node (rosplan_interface_mapping)

### DIFF
--- a/rosplan_demos_interfaces/rosplan_interface_mapping/CMakeLists.txt
+++ b/rosplan_demos_interfaces/rosplan_interface_mapping/CMakeLists.txt
@@ -42,6 +42,7 @@ include_directories(
 
 # waypoint generation server
 add_executable(rp_roadmap_server src/RPRoadmapServer.cpp)
+add_dependencies(rp_roadmap_server rosplan_interface_mapping_generate_messages_cpp)
 target_link_libraries(rp_roadmap_server ${catkin_LIBRARIES})
 
 ##########


### PR DESCRIPTION
Fixes issue where rosplan_interface_mapping needed to be built 2 times, first one to make srv msgs available and second to build the node, with an intermediate error msg. This PR solves the issue and now it only needs to be built one time