### PR TITLE
Add rosplan_planner_interfaces with ffha_planning_interface example launch file

### DIFF
--- a/rosplan_planner_interfaces/CMakeLists.txt
+++ b/rosplan_planner_interfaces/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rosplan_planner_interfaces)
+find_package(catkin REQUIRED)

--- a/rosplan_planner_interfaces/launch/ffha_planner_interface.launch
+++ b/rosplan_planner_interfaces/launch/ffha_planner_interface.launch
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<launch>
+
+	<!-- arguments -->
+	<arg name="node_name"            default="rosplan_planner_interface" />
+	<arg name="use_problem_topic"    default="true" />
+	<arg name="problem_topic"        default="/rosplan_problem_interface/problem_instance" />
+	<arg name="planner_topic"        default="planner_output" />
+	<arg name="domain_path"          default="$(find rosplan_planning_system)/test/pddl/turtlebot/domain.pddl" />
+	<arg name="problem_path"         default="$(find rosplan_planning_system)/test/pddl/turtlebot/problem.pddl" />
+	<arg name="data_path"            default="$(find rosplan_planning_system)/test/pddl/turtlebot/" />
+	<arg name="planner_command"      default="timeout 10 $(find rosplan_planning_system)/common/bin/popf DOMAIN PROBLEM" />
+	<arg name="planner_interface"    default="ff_planner_interface" />
+    <arg name="use_ffha"             default="true" />
+
+	<!-- planner interface -->
+	<node name="$(arg node_name)" pkg="rosplan_planning_system" type="$(arg planner_interface)" respawn="false" output="screen">
+
+		<!-- general options -->
+		<param name="use_problem_topic" value="$(arg use_problem_topic)" />
+
+		<!-- ros topics -->
+		<param name="problem_topic" value="$(arg problem_topic)" />
+		<param name="planner_topic" value="$(arg planner_topic)" />
+
+		<!-- directory for files -->
+		<param name="domain_path" value="$(arg domain_path)" />
+		<param name="problem_path" value="$(arg problem_path)" />
+		<param name="data_path" value="$(arg data_path)" />
+
+		<!-- to run the planner -->
+		<param name="planner_command" value="$(arg planner_command)" />
+
+        <!-- use this param to use either ff_planner_interface with ff planner ("use_ffha" = "false" or ffha planner ("use_ffha" = "true" -->
+        <param name="use_ffha" value="$(arg use_ffha)" />
+		
+	</node>
+
+</launch>

--- a/rosplan_planner_interfaces/package.xml
+++ b/rosplan_planner_interfaces/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>rosplan_planner_interfaces</name>
+  <version>1.0.0</version>
+  <description>rosplan_planner_interfaces repository with example launch files to use planner_interfaces</description>
+
+  <maintainer email="tom.creutz@dfki.de">Tom Creutz</maintainer>
+
+  <license>BSD</license>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+
+  </export>
+</package>


### PR DESCRIPTION
Added a demo package for planning interfaces. It contains an example launch file to use the ff_planner_interface with ffha planner. To test the changes please have a look on the changes at https://github.com/KCL-Planning/ROSPlan/pull/234