### PR TITLE
add RPActionInterface move base example interface in python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# python
+*.pyc
+
 # Prerequisites
 *.d
 

--- a/rosplan_demos_interfaces/rosplan_interface_movebase_py/CMakeLists.txt
+++ b/rosplan_demos_interfaces/rosplan_interface_movebase_py/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5)
+project(rosplan_interface_movebase_py)
+
+find_package(catkin REQUIRED
+ COMPONENTS
+)
+
+catkin_python_setup()
+
+catkin_package(
+ CATKIN_DEPENDS
+)

--- a/rosplan_demos_interfaces/rosplan_interface_movebase_py/README.md
+++ b/rosplan_demos_interfaces/rosplan_interface_movebase_py/README.md
@@ -1,0 +1,18 @@
+# rosplan_interface_movebase_py
+
+Demo on how to use the [RPActionInterface python interface](https://github.com/KCL-Planning/ROSPlan/blob/master/rosplan_planning_system/src/rosplan_planning_system/ActionInterfacePy/RPActionInterface.py) 
+with [move base](http://wiki.ros.org/move_base).
+
+We provide a use case with the turtlebot3.
+
+## Test with turtlebot3
+
+Launch required components:
+
+    roslaunch rosplan_interface_movebase_py rosplan_interface_movebase_py_demo.launch
+
+Run ROSPlan coordination script:
+
+    rosrun rosplan_turtlebot3_demo turtlebot_explore.bash
+
+Done. Watch in rviz the turtlebot3 navigating through some waypoints.

--- a/rosplan_demos_interfaces/rosplan_interface_movebase_py/launch/rosplan_interface_movebase_py_demo.launch
+++ b/rosplan_demos_interfaces/rosplan_interface_movebase_py/launch/rosplan_interface_movebase_py_demo.launch
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <!-- ROSPlan turtlebot3 demo with ROSPlan (using python move base action interface) -->
+
+    <!-- turning off gazebo gui can save resources if you have a slow computer -->
+    <arg name="gazebo_gui" default="true"/>
+
+    <!-- we reuse the demo from rosplan_turtlebot3_demo and tune it to use python interface -->
+    <include file="$(find rosplan_turtlebot3_demo)/launch/turtlebot.launch" >
+        <arg name="interface_type" value="rosplan_interface_movebase_py" />
+        <arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
+    </include>
+
+</launch>

--- a/rosplan_demos_interfaces/rosplan_interface_movebase_py/package.xml
+++ b/rosplan_demos_interfaces/rosplan_interface_movebase_py/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package>
+  <name>rosplan_interface_movebase_py</name>
+  <version>1.0.0</version>
+  <description>
+    Python version of rosplan_interface_movebase
+  </description>
+
+  <license>BSD</license>
+
+  <author email="oscar.lima@dfki.de">Oscar Lima</author>
+  <maintainer email="oscar.lima@dfki.de">Oscar Lima</maintainer>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>rospy</run_depend>
+  <run_depend>rosplan_planning_system</run_depend>
+
+</package>

--- a/rosplan_demos_interfaces/rosplan_interface_movebase_py/scripts/rpmovebase
+++ b/rosplan_demos_interfaces/rosplan_interface_movebase_py/scripts/rpmovebase
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import rosplan_interface_movebase_py.rosplan_interface_movebase
+
+if __name__ == '__main__':
+    rosplan_interface_movebase_py.rosplan_interface_movebase.main()

--- a/rosplan_demos_interfaces/rosplan_interface_movebase_py/setup.py
+++ b/rosplan_demos_interfaces/rosplan_interface_movebase_py/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# for your packages to be recognized by python
+d = generate_distutils_setup(
+  packages=['rosplan_interface_movebase_py'],
+  package_dir={'rosplan_interface_movebase_py': 'src/rosplan_interface_movebase_py'}
+)
+
+setup(**d)

--- a/rosplan_demos_interfaces/rosplan_interface_movebase_py/src/rosplan_interface_movebase_py/rosplan_interface_movebase.py
+++ b/rosplan_demos_interfaces/rosplan_interface_movebase_py/src/rosplan_interface_movebase_py/rosplan_interface_movebase.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+import rospy, tf, actionlib
+import actionlib_msgs.msg
+
+from rosplan_planning_system.ActionInterfacePy.RPActionInterface import RPActionInterface
+from std_srvs.srv import Empty
+from geometry_msgs.msg import PoseStamped
+from move_base_msgs.msg import MoveBaseAction, MoveBaseGoal
+
+class RPMoveBasePy(RPActionInterface):
+    def __init__(self):
+        # call parent constructor
+        RPActionInterface.__init__(self)
+        # setup a move base clear costmap client (to be able to send clear costmap requests later on)
+        rospy.wait_for_service('/move_base/clear_costmaps')
+        self.clear_costmaps_srv_client = rospy.ServiceProxy('/move_base/clear_costmaps', Empty)
+        # get waypoints reference frame from param server
+        self.waypoint_frameid = rospy.get_param('~waypoint_frameid', 'map')
+        self.wp_namespace = rospy.get_param('~wp_namespace', '/rosplan_demo_waypoints/wp')
+        # create move base action client
+        actionserver = rospy.get_param('~action_server', '/move_base')
+        self.action_client = actionlib.SimpleActionClient(actionserver, MoveBaseAction)
+
+    def wpIDtoPoseStamped(self, wpID):
+        result = None
+        if rospy.has_param(self.wp_namespace + '/' + wpID):
+            wp = rospy.get_param(self.wp_namespace + '/' + wpID)
+            if wp:
+                if len(wp) == 3:
+                    result = PoseStamped()
+                    result.header.frame_id = self.waypoint_frameid
+                    # result.header.stamp = rospy.Time.now()
+                    result.pose.position.x = wp[0]
+                    result.pose.position.y = wp[1]
+                    result.pose.position.z = 0.0
+
+                    q = tf.transformations.quaternion_from_euler(0, 0, wp[2])
+                    result.pose.orientation.x = q[0]
+                    result.pose.orientation.y = q[1]
+                    result.pose.orientation.z = q[2]
+                    result.pose.orientation.w = q[3]
+                else:
+                    rospy.logerr('wp size must be equal to 3 : (x, y, and theta)')
+        return result
+
+    def concreteCallback(self, msg):
+        # get waypoint ID from action dispatch msg
+        wpID = ''
+        found = False
+        # iterating over parameters (e.g. kenny, wp0, wp1)
+        for i in range(0, len(msg.parameters)):
+            # check their keys
+            if('to' in msg.parameters[i].key) or ('w1' in msg.parameters[i].key):
+                # wp id found in msg params
+                wpID = msg.parameters[i].value
+                found = True
+        if not found:
+            rospy.loginfo('KCL: ({}) aborting action dispatch PDDL action missing required parameter ?to'.format(self.params.name))
+            return False
+
+        # get waypoint coordinates from its ID via query to parameter server
+        pose = PoseStamped()
+        pose = self.wpIDtoPoseStamped(wpID)
+        if not pose:
+            rospy.logerr('Waypoint not found in parameter server')
+            return False
+
+        rospy.loginfo('KCL: ({}) waiting for move_base action server to start'.format(self.params.name))
+        self.action_client.wait_for_server()
+
+        # dispatch MoveBase action
+        goal = MoveBaseGoal()
+        goal.target_pose = pose
+        self.action_client.send_goal(goal)
+
+        finished_before_timeout = self.action_client.wait_for_result()
+        if finished_before_timeout:
+
+            state = self.action_client.get_state()
+            rospy.loginfo('KCL: ({}) action finished: {}'.format(self.params.name, state))
+
+            if state == actionlib_msgs.msg.GoalStatus.SUCCEEDED:
+                # publish feedback (achieved)
+                return True
+            else:
+                # clear costmaps
+                self.clear_costmaps_srv_client(Empty())
+                # publish feedback (failed)
+                return False
+        else:
+            # timed out (failed)
+            self.action_client.cancelAllGoals()
+            rospy.loginfo('KCL: ({}) action timed out'.format(self.params.name))
+            return False
+
+def main():
+    rospy.init_node('rosplan_interface_movebase', anonymous=False)
+    rpmb = RPMoveBasePy()
+    rpmb.runActionInterface()

--- a/rosplan_turtlebot3_demo/launch/turtlebot.launch
+++ b/rosplan_turtlebot3_demo/launch/turtlebot.launch
@@ -6,6 +6,9 @@
     <arg name="map_file" default="$(find rosplan_turtlebot3_demo)/maps/playground.yaml"/>
     <arg name="gazebo_gui" default="true"/>
 
+    <!-- select between a python or a c++ rosplan move base interface (default: C++) -->
+    <arg name="interface_type" default="rosplan_interface_movebase"/> <!-- python alternative: rosplan_interface_movebase_py -->
+
     <!-- turtlebot3 simulation -->
     <include file="$(find rosplan_turtlebot3_demo)/launch/turtlebot3_bringup_sim.launch" >
         <arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
@@ -33,7 +36,7 @@
     </include>
 
     <!-- rosplan move base action interface, makes link between rosplan dispatcher and hardware -->
-    <node pkg="rosplan_interface_movebase" type="rpmovebase" name="rosplan_interface_movebase" respawn="false" output="screen">
+    <node pkg="$(arg interface_type)" type="rpmovebase" name="rosplan_interface_movebase" respawn="false" output="screen">
         <param name="knowledge_base" value="rosplan_knowledge_base" />
         <param name="action_server" value="/move_base" />
         <param name="pddl_action_name" value="goto_waypoint" />


### PR DESCRIPTION
PR to address #37 .

Provides with a python example of an action interface in ROSPlan (for move_base).

This PR is related to https://github.com/KCL-Planning/ROSPlan/pull/239 and should be merged at same time.