### PR TITLE
Change tb2->tb3 in tb3 demo. Fixes #44

### DIFF
--- a/rosplan_turtlebot3_demo/scripts/turtlebot_explore.bash
+++ b/rosplan_turtlebot3_demo/scripts/turtlebot_explore.bash
@@ -5,4 +5,4 @@ echo "Generating waypoints.";
 rosservice call /rosplan_roadmap_server/create_prm "{nr_waypoints: 10, min_distance: 0.3, casting_distance: 2.0, connecting_distance: 8.0, occupancy_threshold: 10, total_attempts: 10}";
 
 # call turtlebot_explore_common.bash script
-bash `rospack find rosplan_turtlebot2_demo`/scripts/turtlebot_explore_common.bash
+bash `rospack find rosplan_turtlebot3_demo`/scripts/turtlebot_explore_common.bash

--- a/rosplan_turtlebot3_demo/scripts/turtlebot_explore_wp_from_file.bash
+++ b/rosplan_turtlebot3_demo/scripts/turtlebot_explore_wp_from_file.bash
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # load waypoints into parameter server
-rosparam load `rospack find rosplan_turtlebot2_demo`/config/waypoints.yaml;
+rosparam load `rospack find rosplan_turtlebot3_demo`/config/waypoints.yaml;
 
 # let RoadmapServer know that wps are available in param server
 rosservice call /rosplan_roadmap_server/load_waypoints;
 
 # call turtlebot_explore_common.bash script
-bash `rospack find rosplan_turtlebot2_demo`/scripts/turtlebot_explore_common.bash
+bash `rospack find rosplan_turtlebot3_demo`/scripts/turtlebot_explore_common.bash


### PR DESCRIPTION
Some names were not changed when moved to turtlebot 3, as reported in #44.