### PR TITLE
fix markers not showing on rviz

### DIFF
--- a/rosplan_demos_interfaces/rosplan_interface_mapping/launch/rosplan_roadmap_server.launch
+++ b/rosplan_demos_interfaces/rosplan_interface_mapping/launch/rosplan_roadmap_server.launch
@@ -19,7 +19,7 @@
     <arg name="costmap_topic" default="/move_base/global_costmap/costmap" />
 
     <!-- the reference frame in which the map coordinates are expressed -->
-    <arg name="wp_reference_frame" default="/map" />
+    <arg name="wp_reference_frame" default="map" />
 
     <!-- the mapping interface will wait for this max. amount of time looking for KB and map services -->
     <arg name="srv_timeout" default="3.0" />


### PR DESCRIPTION
change /map reference frame to map (no slash).
This fixes a strange problem present in ROS noetic where the visualisation markers of the navigation graph are not showing.